### PR TITLE
Fix hash probes

### DIFF
--- a/src/bloom_filter/__init__.py
+++ b/src/bloom_filter/__init__.py
@@ -3,12 +3,12 @@
 
 from .bloom_filter import (
     BloomFilter,
-    get_bitno_lin_comb,
+    get_filter_bitno_probes,
     get_bitno_seed_rnd,
 )
 
 __all__ = [
     'BloomFilter',
-    'get_bitno_lin_comb',
+    'get_filter_bitno_probes',
     'get_bitno_seed_rnd',
 ]

--- a/src/bloom_filter/bloom_filter.py
+++ b/src/bloom_filter/bloom_filter.py
@@ -465,7 +465,7 @@ def hash2(int_list):
     return simple_hash(int_list, MERSENNES2[0], MERSENNES2[1], MERSENNES2[2])
 
 
-def get_bitno_lin_comb(bloom_filter, key):
+def get_filter_bitno_probes(bloom_filter, key):
     """Apply num_probes_k hash functions to key.  Generate the array index and bitmask corresponding to each result"""
 
     # This one assumes key is either bytes or str (or other list of integers)
@@ -510,7 +510,7 @@ class BloomFilter(object):
     def __init__(self,
                  max_elements=10000,
                  error_rate=0.1,
-                 probe_bitnoer=get_bitno_lin_comb,
+                 probe_bitnoer=get_filter_bitno_probes,
                  filename=None,
                  start_fresh=False):
         # pylint: disable=R0913

--- a/src/bloom_filter/bloom_filter.py
+++ b/src/bloom_filter/bloom_filter.py
@@ -489,11 +489,11 @@ def get_filter_bitno_probes(bloom_filter, key):
     hash_value2 = hash2(int_list)
     probe_value = hash_value1
 
-    # Use exponentiation to generate uncorrelated values for hash probes
     for probeno in range(1, bloom_filter.num_probes_k + 1):
-        probe_value *= probeno * hash_value2
-        probe_value %= bloom_filter.num_bits_m
-        yield probe_value
+        probe_value *= hash_value1
+        probe_value += hash_value2
+        probe_value %= MERSENNES1[2]
+        yield probe_value % bloom_filter.num_bits_m
 
 
 def try_unlink(filename):

--- a/src/bloom_filter/bloom_filter.py
+++ b/src/bloom_filter/bloom_filter.py
@@ -487,11 +487,13 @@ def get_bitno_lin_comb(bloom_filter, key):
 
     hash_value1 = hash1(int_list)
     hash_value2 = hash2(int_list)
+    probe_value = hash_value1
 
-    # We're using linear combinations of hash_value1 and hash_value2 to obtain num_probes_k hash functions
+    # Use exponentiation to generate uncorrelated values for hash probes
     for probeno in range(1, bloom_filter.num_probes_k + 1):
-        bit_index = hash_value1 + probeno * hash_value2
-        yield bit_index % bloom_filter.num_bits_m
+        probe_value *= probeno * hash_value2
+        probe_value %= bloom_filter.num_bits_m
+        yield probe_value
 
 
 def try_unlink(filename):

--- a/tests/test_bloom_filter.py
+++ b/tests/test_bloom_filter.py
@@ -39,7 +39,7 @@ def _test(description, values, trials, error_rate, probe_bitnoer=None, filename=
     # R0914: We want some local variables too.  This is just test code.
     """Some quick automatic tests for the bloom filter class"""
     if not probe_bitnoer:
-        probe_bitnoer = bloom_filter.get_bitno_lin_comb
+        probe_bitnoer = bloom_filter.get_filter_bitno_probes
 
     all_good = True
 

--- a/tests/test_bloom_filter.py
+++ b/tests/test_bloom_filter.py
@@ -46,7 +46,7 @@ def _test(description, values, trials, error_rate, probe_bitnoer=None, filename=
     divisor = 100000
 
     bloom = bloom_filter.BloomFilter(
-        max_elements=trials * 2,
+        max_elements=values.length() * 2,
         error_rate=error_rate,
         probe_bitnoer=probe_bitnoer,
         filename=filename,
@@ -294,6 +294,7 @@ def test_bloom_filter():
     all_good &= _test('states', States(), trials=100000, error_rate=0.01)
 
     all_good &= _test('random', Random_content(), trials=10000, error_rate=0.1)
+    all_good &= _test('random', Random_content(), trials=1000000, error_rate=1E-9)
     all_good &= _test('random', Random_content(), trials=10000, error_rate=0.1,
                       probe_bitnoer=bloom_filter.get_bitno_seed_rnd)
 


### PR DESCRIPTION
I changed the probe logic to make collisions less likely. Using a linear combination is susceptible to false positives because if hash2 has a high GCD with bloom_filter.num_bits_m, then it will not produce very many different hash values (it will produce precisely min(num_probes_k, num_bits_m/GCD(num_bits_m, hash2)), meaning that there are fewer opportunities for it to produce a hash that's not in the filter.

Ideally this should use python's random() functionality, so long as the random generator uses all the entropy of the seeds, but it looks like it uses only an int's worth: https://docs.python.org/3/library/random.html#random.seed