### PR TITLE
Update bloom_filter.py

### DIFF
--- a/src/bloom_filter/bloom_filter.py
+++ b/src/bloom_filter/bloom_filter.py
@@ -81,7 +81,7 @@ if HAVE_MMAP:
         Please note that this has only been tested on Linux so far: 2    -11-01.
         """
 
-        effs = 2 ^ 8 - 1
+        effs = 2 ** 8 - 1
 
         def __init__(self, num_bits, filename):
             self.num_bits = num_bits


### PR DESCRIPTION
Fix incorrect use of XOR operator to use correct POWER operator.  In Python "2 ^ N" means "2 XOR N" whereas "2 ** N" means "2 to the power N". The fact that this change still passes all tests either indicates that there are serious test flaws.